### PR TITLE
Adding Azure sovereign cloud support

### DIFF
--- a/azure/config.go
+++ b/azure/config.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"errors"
 	"net/url"
+	"strconv"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 
@@ -29,6 +30,7 @@ const (
 const Kind = "azure"
 const defaultBaseUrl = "core.windows.net"
 const defaultAPIVersion = "2018-03-28"
+const defaultHTTPSStr = "true"
 
 func init() {
 	validatefn := func(config stow.Config) error {
@@ -109,15 +111,11 @@ func getAccount(cfg stow.Config) (account, key string, baseUrl string, APIVersio
 	var useHTTPSStr string
 	useHTTPSStr, ok = cfg.Config(ConfigUseHTTPS)
 	if !ok {
-		useHTTPSStr = ""
+		useHTTPSStr = defaultHTTPSStr
 	}
-	switch useHTTPSStr {
-	case "true":
-		useHTTPS = true
-	case "false":
-		useHTTPS = false
-	default:
-		useHTTPS = true
+	useHTTPS, err = strconv.ParseBool(useHTTPSStr)
+	if err != nil {
+		return "", "", "", "", false, errors.New("invalid value for use_https_str")
 	}
 	return acc, key, baseUrl, APIVersion, useHTTPS, nil
 }

--- a/azure/config.go
+++ b/azure/config.go
@@ -12,14 +12,14 @@ import (
 	"github.com/flyteorg/stow"
 )
 
-// ConfigAccount and ConfigKey are the supported configuration items for
-// Azure blob storage.
-// SovereignCloud only supports "us" but there are other options listed
+// ConfigAccount should be the name of your storage account in the Azure portal
+// ConfigKey should be an access key
+// ConfigCloud can be one of "public", "germany", "us", or "china". Defaults to public.
 // https://pkg.go.dev/github.com/Azure/go-autorest/autorest/azure#Environment
 const (
 	ConfigAccount = "account"
 	ConfigKey     = "key"
-	ConfigCloud   = "cloud"
+	ConfigCloud   = "public"
 )
 
 // Kind is the kind of Location this package provides.
@@ -99,7 +99,7 @@ func getAccount(cfg stow.Config) (account, key string, env azure.Environment, er
 	switch cloud {
 	case "us":
 		env = azure.USGovernmentCloud
-	case "german":
+	case "germany":
 		env = azure.GermanCloud
 	case "china":
 		env = azure.ChinaCloud

--- a/azure/config.go
+++ b/azure/config.go
@@ -2,9 +2,11 @@ package azure
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/go-autorest/autorest/azure"
 
 	az "github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/flyteorg/stow"
@@ -12,9 +14,12 @@ import (
 
 // ConfigAccount and ConfigKey are the supported configuration items for
 // Azure blob storage.
+// SovereignCloud only supports "us" but there are other options listed
+// https://pkg.go.dev/github.com/Azure/go-autorest/autorest/azure#Environment
 const (
 	ConfigAccount = "account"
 	ConfigKey     = "key"
+	ConfigCloud   = "cloud"
 )
 
 // Kind is the kind of Location this package provides.
@@ -45,14 +50,14 @@ func init() {
 			config: config,
 		}
 
-		acc, key, err := getAccount(l.config)
+		acc, key, env, err := getAccount(l.config)
 		if err != nil {
 			return nil, err
 		}
 
 		l.account = acc
 
-		l.client, err = newBlobStorageClient(acc, key)
+		l.client, err = newBlobStorageClient(acc, key, env)
 		if err != nil {
 			return nil, err
 		}
@@ -76,22 +81,38 @@ func init() {
 	stow.Register(Kind, makefn, kindfn, validatefn)
 }
 
-func getAccount(cfg stow.Config) (account, key string, err error) {
+func getAccount(cfg stow.Config) (account, key string, env azure.Environment, err error) {
 	acc, ok := cfg.Config(ConfigAccount)
 	if !ok {
-		return "", "", errors.New("missing account id")
+		return "", "", azure.Environment{}, errors.New("missing account id")
 	}
 
 	key, ok = cfg.Config(ConfigKey)
 	if !ok {
-		return "", "", errors.New("missing auth key")
+		return "", "", azure.Environment{}, errors.New("missing auth key")
 	}
 
-	return acc, key, nil
+	cloud, ok := cfg.Config(ConfigCloud)
+	if !ok {
+		return "", "", azure.Environment{}, errors.New("missing auth key")
+	}
+	switch cloud {
+	case "us":
+		env = azure.USGovernmentCloud
+	case "german":
+		env = azure.GermanCloud
+	case "china":
+		env = azure.ChinaCloud
+	case "public":
+		env = azure.PublicCloud
+	default:
+		return "", "", azure.Environment{}, fmt.Errorf("invalid cloud %s", cloud)
+	}
+	return acc, key, env, nil
 }
 
-func newBlobStorageClient(account, key string) (*az.BlobStorageClient, error) {
-	basicClient, err := az.NewBasicClient(account, key)
+func newBlobStorageClient(account, key string, env azure.Environment) (*az.BlobStorageClient, error) {
+	basicClient, err := az.NewBasicClientOnSovereignCloud(account, key, env)
 	if err != nil {
 		return nil, errors.New("bad credentials")
 	}

--- a/azure/config.go
+++ b/azure/config.go
@@ -14,19 +14,21 @@ import (
 // ConfigKey should be an access key
 // ConfigBaseUrl is the base URL of the cloud you want to connect to. The default
 // is Azure Public cloud
-// ConfigDefaultAPIVersion is the Azure Storage API version string used when a
+// ConfigAPIVersion is the Azure Storage API version string used when a
 // client is created.
 // ConfigUseHTTPS specifies whether you want to use HTTPS to connect
 const (
-	ConfigAccount           = "account"
-	ConfigKey               = "key"
-	ConfigBaseUrl           = "base_url"
-	ConfigDefaultAPIVersion = "default_api_version"
-	ConfigUseHTTPS          = "use_https"
+	ConfigAccount    = "account"
+	ConfigKey        = "key"
+	ConfigBaseUrl    = "base_url"
+	ConfigAPIVersion = "api_version"
+	ConfigUseHTTPS   = "use_https"
 )
 
 // Kind is the kind of Location this package provides.
 const Kind = "azure"
+const defaultBaseUrl = "core.windows.net"
+const defaultAPIVersion = "2018-03-28"
 
 func init() {
 	validatefn := func(config stow.Config) error {
@@ -84,7 +86,7 @@ func init() {
 	stow.Register(Kind, makefn, kindfn, validatefn)
 }
 
-func getAccount(cfg stow.Config) (account, key string, baseUrl string, defaultAPIVersion string, useHTTPS bool, err error) {
+func getAccount(cfg stow.Config) (account, key string, baseUrl string, APIVersion string, useHTTPS bool, err error) {
 	acc, ok := cfg.Config(ConfigAccount)
 	if !ok {
 		return "", "", "", "", false, errors.New("missing account id")
@@ -97,11 +99,11 @@ func getAccount(cfg stow.Config) (account, key string, baseUrl string, defaultAP
 
 	baseUrl, ok = cfg.Config(ConfigBaseUrl)
 	if !ok {
-		baseUrl = "core.windows.net"
+		baseUrl = defaultBaseUrl
 	}
-	defaultAPIVersion, ok = cfg.Config(ConfigDefaultAPIVersion)
+	APIVersion, ok = cfg.Config(ConfigAPIVersion)
 	if !ok {
-		defaultAPIVersion = "2018-03-28"
+		APIVersion = defaultAPIVersion
 	}
 
 	var useHTTPSStr string
@@ -117,11 +119,11 @@ func getAccount(cfg stow.Config) (account, key string, baseUrl string, defaultAP
 	default:
 		useHTTPS = true
 	}
-	return acc, key, baseUrl, defaultAPIVersion, useHTTPS, nil
+	return acc, key, baseUrl, APIVersion, useHTTPS, nil
 }
 
-func newBlobStorageClient(account, key string, baseUrl string, defaultAPIVersion string, useHTTPS bool) (*az.BlobStorageClient, error) {
-	basicClient, err := az.NewClient(account, key, baseUrl, defaultAPIVersion, useHTTPS)
+func newBlobStorageClient(account, key string, baseUrl string, APIVersion string, useHTTPS bool) (*az.BlobStorageClient, error) {
+	basicClient, err := az.NewClient(account, key, baseUrl, APIVersion, useHTTPS)
 	if err != nil {
 		return nil, errors.New("bad credentials")
 	}

--- a/azure/doc.go
+++ b/azure/doc.go
@@ -1,22 +1,23 @@
 /*
 Package azure provides an abstraction for the Microsoft Azure Storage service. In this package, an Azure Resource of type "Storage account" is represented by a Stow Location and an Azure blob is represented by a Stow Item.
 
-Usage and Credentials
+# Usage and Credentials
 
-Two peices of information are needed to access an Azure Resorce of type "Storage account": the Resource Name (found in the "All Resources" tab of the Azure Portal console) and the Access Key (found in the "Access Keys" tab in the "Settings" pane of a Resource's details page).
+Two pieces of information are needed to access an Azure Resorce of type "Storage account": the Resource Name (found in the "All Resources" tab of the Azure Portal console) and the Access Key (found in the "Access Keys" tab in the "Settings" pane of a Resource's details page).
 
 stow.Dial requires both a string value of the particular Stow Location Kind ("azure") and a stow.Config instance. The stow.Config instance requires two entries with the specific key value attributes:
 
 - a key of azure.ConfigAccount with a value of the Azure Resource Name
 - a key of azure.ConfigKey with a value of the Azure Access Key
+- an optional key of azure.ConfigCloud to specify which Sovereign Cloud you'd like to connect to. Options are "public" (default), "us", "germany", or "china"
 
-Location
+# Location
 
 There are azure.location methods which allow the retrieval of a single Azure Storage Service. A stow.Item representation of an Azure Storage Blob can also be retrieved based on the Object's URL (ItemByURL).
 
 Additional azure.location methods provide capabilities to create and remove Azure Storage Containers.
 
-Container
+# Container
 
 Methods of an azure.container allow the retrieval of an Azure Storage Container's:
 
@@ -28,7 +29,7 @@ Additional azure.container methods allow Stow to :
 - remove a Blob (RemoveItem)
 - update or create a Blob (Put)
 
-Item
+# Item
 
 Methods of azure.Item allow the retrieval of an Azure Storage Container's:
 - name (ID or name)
@@ -39,7 +40,7 @@ Methods of azure.Item allow the retrieval of an Azure Storage Container's:
 - Etag
 - content
 
-Caveats
+# Caveats
 
 At this point in time, the upload limit of a blob is about 60MB. This is an implementation restraint.
 */

--- a/azure/doc.go
+++ b/azure/doc.go
@@ -10,7 +10,7 @@ stow.Dial requires both a string value of the particular Stow Location Kind ("az
 - a key of azure.ConfigAccount with a value of the Azure Resource Name
 - a key of azure.ConfigKey with a value of the Azure Access Key
 - an optional key of azure.ConfigBaseUrl to specify which base URL you would like to use. Defaults to public Azure.
-- an optional key of azure.ConfigDefaultAPIVersion to specify which Storage API version you would like to use. Defaults to 2018-03-28
+- an optional key of azure.ConfigAPIVersion to specify which Storage API version you would like to use. Defaults to 2018-03-28
 - an optional key of azure.ConfigUseHTTPS to specify whether to use HTTPS. Defaults to true
 
 # Location

--- a/azure/doc.go
+++ b/azure/doc.go
@@ -9,9 +9,9 @@ stow.Dial requires both a string value of the particular Stow Location Kind ("az
 
 - a key of azure.ConfigAccount with a value of the Azure Resource Name
 - a key of azure.ConfigKey with a value of the Azure Access Key
-- an optional key of azure.ConfigBaseUrl to specify which base URL you would like to use. Defaults to public Azure.
+- an optional key of azure.ConfigBaseUrl to specify which base URL you would like to use. Defaults to core.windows.net (public Azure)
 - an optional key of azure.ConfigAPIVersion to specify which Storage API version you would like to use. Defaults to 2018-03-28
-- an optional key of azure.ConfigUseHTTPS to specify whether to use HTTPS. Defaults to true
+- an optional key of azure.ConfigUseHTTPS to specify whether to use HTTPS when connecting to Azure storage. Defaults to true
 
 # Location
 

--- a/azure/doc.go
+++ b/azure/doc.go
@@ -9,7 +9,9 @@ stow.Dial requires both a string value of the particular Stow Location Kind ("az
 
 - a key of azure.ConfigAccount with a value of the Azure Resource Name
 - a key of azure.ConfigKey with a value of the Azure Access Key
-- an optional key of azure.ConfigCloud to specify which Sovereign Cloud you'd like to connect to. Options are "public" (default), "us", "germany", or "china"
+- an optional key of azure.ConfigBaseUrl to specify which base URL you would like to use. Defaults to public Azure.
+- an optional key of azure.ConfigDefaultAPIVersion to specify which Storage API version you would like to use. Defaults to 2018-03-28
+- an optional key of azure.ConfigUseHTTPS to specify whether to use HTTPS. Defaults to true
 
 # Location
 


### PR DESCRIPTION
# What changed

Stow's current implementation of Azure Storage support uses [NewBasicClient](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/storage#NewBasicClient) which [defaults to a core.windows.net](https://github.com/Azure/azure-sdk-for-go/blob/v68.0.0/storage/client.go#L34) storage URL. This PR switches to [NewClient](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/storage#NewClient) which supports an arbitrary user-defined base URL. If the user does not pass in a base_url, we default to using core.windows.net (public cloud), thereby avoiding any breaking changes. 

# Why this change is necessary

Sovereign clouds like US Government, China, and Germany have different base URLs. Without this PR, users will be unable to helm install flyte when using Azure Storage in sovereign clouds. Container creation fails with a 403 forbidden error.