### PR TITLE
Adds Azure sovereign cloud support to getSignedUrl

### DIFF
--- a/azure/config.go
+++ b/azure/config.go
@@ -99,7 +99,7 @@ func getAccount(cfg stow.Config) (account, key string, baseUrl string, APIVersio
 		return "", "", "", "", false, errors.New("missing auth key")
 	}
 
-	baseUrl = getBaseAzureUrlOrDefault(cfg)
+	baseUrl = GetBaseAzureUrlOrDefault(cfg)
 
 	APIVersion, ok = cfg.Config(ConfigAPIVersion)
 	if !ok {
@@ -118,7 +118,7 @@ func getAccount(cfg stow.Config) (account, key string, baseUrl string, APIVersio
 	return acc, key, baseUrl, APIVersion, useHTTPS, nil
 }
 
-func getBaseAzureUrlOrDefault(cfg stow.Config) string {
+func GetBaseAzureUrlOrDefault(cfg stow.Config) string {
 	baseUrl, ok := cfg.Config(ConfigBaseUrl)
 	if !ok || baseUrl == "" {
 		baseUrl = defaultBaseUrl

--- a/azure/config.go
+++ b/azure/config.go
@@ -120,7 +120,7 @@ func getAccount(cfg stow.Config) (account, key string, baseUrl string, APIVersio
 
 func GetBaseAzureUrlOrDefault(cfg stow.Config) string {
 	baseUrl, ok := cfg.Config(ConfigBaseUrl)
-	if !ok {
+	if !ok || baseUrl == "" {
 		baseUrl = defaultBaseUrl
 	}
 	return baseUrl

--- a/azure/config.go
+++ b/azure/config.go
@@ -99,10 +99,8 @@ func getAccount(cfg stow.Config) (account, key string, baseUrl string, APIVersio
 		return "", "", "", "", false, errors.New("missing auth key")
 	}
 
-	baseUrl, ok = cfg.Config(ConfigBaseUrl)
-	if !ok {
-		baseUrl = defaultBaseUrl
-	}
+	baseUrl = GetBaseAzureUrlOrDefault(cfg)
+
 	APIVersion, ok = cfg.Config(ConfigAPIVersion)
 	if !ok {
 		APIVersion = defaultAPIVersion
@@ -118,6 +116,14 @@ func getAccount(cfg stow.Config) (account, key string, baseUrl string, APIVersio
 		return "", "", "", "", false, errors.New("invalid value for use_https_str")
 	}
 	return acc, key, baseUrl, APIVersion, useHTTPS, nil
+}
+
+func GetBaseAzureUrlOrDefault(cfg stow.Config) string {
+	baseUrl, ok := cfg.Config(ConfigBaseUrl)
+	if !ok {
+		baseUrl = defaultBaseUrl
+	}
+	return baseUrl
 }
 
 func newBlobStorageClient(account, key string, baseUrl string, APIVersion string, useHTTPS bool) (*az.BlobStorageClient, error) {

--- a/azure/config.go
+++ b/azure/config.go
@@ -99,7 +99,7 @@ func getAccount(cfg stow.Config) (account, key string, baseUrl string, APIVersio
 		return "", "", "", "", false, errors.New("missing auth key")
 	}
 
-	baseUrl = GetBaseAzureUrlOrDefault(cfg)
+	baseUrl = getBaseAzureUrlOrDefault(cfg)
 
 	APIVersion, ok = cfg.Config(ConfigAPIVersion)
 	if !ok {
@@ -118,7 +118,7 @@ func getAccount(cfg stow.Config) (account, key string, baseUrl string, APIVersio
 	return acc, key, baseUrl, APIVersion, useHTTPS, nil
 }
 
-func GetBaseAzureUrlOrDefault(cfg stow.Config) string {
+func getBaseAzureUrlOrDefault(cfg stow.Config) string {
 	baseUrl, ok := cfg.Config(ConfigBaseUrl)
 	if !ok || baseUrl == "" {
 		baseUrl = defaultBaseUrl

--- a/azure/container.go
+++ b/azure/container.go
@@ -25,6 +25,7 @@ type container struct {
 	properties az.ContainerProperties
 	client     *az.BlobStorageClient
 	creds      *azblob.SharedKeyCredential
+	baseUrl    string
 }
 
 var _ stow.Container = (*container)(nil)
@@ -64,7 +65,7 @@ func (c *container) PreSignRequest(_ context.Context, method stow.ClientMethod, 
 
 	// Create the SAS URL for the resource you wish to access, and append the SAS query parameters.
 	qp := sasQueryParams.Encode()
-	return fmt.Sprintf("https://%s.blob.core.windows.net/%s/%s?%s", c.account, containerName, blobName, qp), nil
+	return fmt.Sprintf("https://%s.blob.%s/%s/%s?%s", c.account, c.baseUrl, containerName, blobName, qp), nil
 }
 
 func (c *container) Item(id string) (stow.Item, error) {

--- a/azure/location.go
+++ b/azure/location.go
@@ -31,7 +31,7 @@ func (l *location) CreateContainer(name string) (stow.Container, error) {
 		}
 		return nil, err
 	}
-	baseUrl := getBaseAzureUrlOrDefault(l.config)
+	baseUrl := GetBaseAzureUrlOrDefault(l.config)
 
 	container := &container{
 		id: name,
@@ -59,7 +59,7 @@ func (l *location) Containers(prefix, cursor string, count int) ([]stow.Containe
 	}
 	containers := make([]stow.Container, len(response.Containers))
 	for i, azureContainer := range response.Containers {
-		baseUrl := getBaseAzureUrlOrDefault(l.config)
+		baseUrl := GetBaseAzureUrlOrDefault(l.config)
 		containers[i] = &container{
 			id:         azureContainer.Name,
 			properties: azureContainer.Properties,

--- a/azure/location.go
+++ b/azure/location.go
@@ -31,12 +31,14 @@ func (l *location) CreateContainer(name string) (stow.Container, error) {
 		}
 		return nil, err
 	}
+	baseUrl, _ := l.config.Config(ConfigBaseUrl)
 	container := &container{
 		id: name,
 		properties: az.ContainerProperties{
 			LastModified: time.Now().Format(timeFormat),
 		},
-		client: l.client,
+		client:  l.client,
+		baseUrl: baseUrl,
 	}
 	time.Sleep(time.Second * 3)
 	return container, nil

--- a/azure/location.go
+++ b/azure/location.go
@@ -59,12 +59,14 @@ func (l *location) Containers(prefix, cursor string, count int) ([]stow.Containe
 	}
 	containers := make([]stow.Container, len(response.Containers))
 	for i, azureContainer := range response.Containers {
+		baseUrl := GetBaseAzureUrlOrDefault(l.config)
 		containers[i] = &container{
 			id:         azureContainer.Name,
 			properties: azureContainer.Properties,
 			client:     l.client,
 			creds:      l.sharedCreds,
 			account:    l.account,
+			baseUrl:    baseUrl,
 		}
 	}
 	return containers, response.NextMarker, nil

--- a/azure/location.go
+++ b/azure/location.go
@@ -31,7 +31,7 @@ func (l *location) CreateContainer(name string) (stow.Container, error) {
 		}
 		return nil, err
 	}
-	baseUrl := GetBaseAzureUrlOrDefault(l.config)
+	baseUrl := getBaseAzureUrlOrDefault(l.config)
 
 	container := &container{
 		id: name,
@@ -59,7 +59,7 @@ func (l *location) Containers(prefix, cursor string, count int) ([]stow.Containe
 	}
 	containers := make([]stow.Container, len(response.Containers))
 	for i, azureContainer := range response.Containers {
-		baseUrl := GetBaseAzureUrlOrDefault(l.config)
+		baseUrl := getBaseAzureUrlOrDefault(l.config)
 		containers[i] = &container{
 			id:         azureContainer.Name,
 			properties: azureContainer.Properties,

--- a/azure/location.go
+++ b/azure/location.go
@@ -31,7 +31,8 @@ func (l *location) CreateContainer(name string) (stow.Container, error) {
 		}
 		return nil, err
 	}
-	baseUrl, _ := l.config.Config(ConfigBaseUrl)
+	baseUrl := GetBaseAzureUrlOrDefault(l.config)
+
 	container := &container{
 		id: name,
 		properties: az.ContainerProperties{


### PR DESCRIPTION
In #7 I forgot to add support for the `baseUrl` parameter to the `PreSignRequest` method.

PreSignRequest is called by [CreateSignedUrl in the flyteadmin dataproxy service](https://github.com/flyteorg/flyteadmin/blob/d492640dbd9e72b9a50259799aba76ce85b16313/dataproxy/service.go#L131). Without this change, "fast" pyflyte registration in sovereign cloud will fail.