### PR TITLE
Add support for KMS SSE to S3 backend

### DIFF
--- a/azure/config.go
+++ b/azure/config.go
@@ -3,10 +3,11 @@ package azure
 import (
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"net/url"
 	"strconv"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 
 	"github.com/flyteorg/stow"
 )

--- a/azure/container.go
+++ b/azure/container.go
@@ -3,13 +3,14 @@ package azure
 import (
 	"context"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 	"io"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 
 	azcontainer "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/flyteorg/stow"

--- a/azure/item.go
+++ b/azure/item.go
@@ -2,11 +2,12 @@ package azure
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"io"
 	"net/url"
 	"sync"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 
 	"github.com/flyteorg/stow"
 )

--- a/azure/location.go
+++ b/azure/location.go
@@ -3,15 +3,17 @@ package azure
 import (
 	"context"
 	"errors"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"net/http"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
-	azcontainer "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	azcontainer "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 
 	"github.com/flyteorg/stow"
 )

--- a/go.mod
+++ b/go.mod
@@ -57,3 +57,5 @@ require (
 	google.golang.org/genproto v0.0.0-20220426171045-31bebdecfb46 // indirect
 	google.golang.org/grpc v1.46.0 // indirect
 )
+
+replace github.com/flyteorg/stow => github.com/ddl-rliu/stow v0.0.17

--- a/go.mod
+++ b/go.mod
@@ -57,5 +57,3 @@ require (
 	google.golang.org/genproto v0.0.0-20220426171045-31bebdecfb46 // indirect
 	google.golang.org/grpc v1.46.0 // indirect
 )
-
-replace github.com/flyteorg/stow => github.com/ddl-rliu/stow v0.0.17

--- a/s3/config.go
+++ b/s3/config.go
@@ -50,6 +50,11 @@ const (
 	// Its default value is "false", to enable set to "true".
 	// This feature is useful for s3-compatible blob stores -- ie minio.
 	ConfigV2Signing = "v2_signing"
+
+	// ConfigExtraArgs is an optional config value for extra arguments passed to S3 upload,
+	// a string representing a JSON object of key/value pairs
+	// This feature is useful for setting server-side encryption headers.
+	ConfigExtraArgs = "extra_args"
 )
 
 func init() {

--- a/s3/container.go
+++ b/s3/container.go
@@ -44,7 +44,6 @@ func (c *container) PreSignRequest(ctx context.Context, clientMethod stow.Client
 			contentMD5 = aws.String(params.ContentMD5)
 		}
 
-		// getKMSMasterKeyID(c.client, c.name)
 		params := &s3.PutObjectInput{
 			Bucket:     aws.String(c.name),
 			Key:        aws.String(id),

--- a/s3/container.go
+++ b/s3/container.go
@@ -346,7 +346,7 @@ func getKMSMasterKeyID(svc *s3.S3, bucketName string) (bucketEncrypted bool, sse
 		log.Printf("Bucket %v has been encrypted with AES256", bucketName)
 		return true, s3.ServerSideEncryptionAes256, ""
 	default:
-		log.Printf("fin Bucket is not encrypted")
+		log.Printf("Bucket is not encrypted")
 		return false, "", ""
 	}
 }

--- a/s3/location.go
+++ b/s3/location.go
@@ -34,13 +34,15 @@ func (l *location) CreateContainer(containerName string) (stow.Container, error)
 		return nil, errors.Wrap(err, "CreateContainer, creating the bucket")
 	}
 
-	region, _ := l.config.Config("region")
+	region, _ := l.config.Config(ConfigRegion)
+	extraArgs, _ := l.config.Config(ConfigExtraArgs)
 
 	newContainer := &container{
 		name:           containerName,
 		client:         l.client,
 		region:         region,
 		customEndpoint: l.customEndpoint,
+		extraArgs:      extraArgs,
 	}
 
 	return newContainer, nil
@@ -124,11 +126,13 @@ func (l *location) Containers(prefix, cursor string, count int) ([]stow.Containe
 			}
 		}
 
+		extraArgs, _ := l.config.Config(ConfigExtraArgs)
 		newContainer := &container{
 			name:           *(bucket.Name),
 			client:         client,
 			region:         bucketRegion,
 			customEndpoint: l.customEndpoint,
+			extraArgs:      extraArgs,
 		}
 
 		containers = append(containers, newContainer)
@@ -163,11 +167,13 @@ func (l *location) Container(id string) (stow.Container, error) {
 		}
 	}
 
+	extraArgs, _ := l.config.Config(ConfigExtraArgs)
 	c := &container{
 		name:           id,
 		client:         client,
 		region:         bucketRegion,
 		customEndpoint: l.customEndpoint,
+		extraArgs:      extraArgs,
 	}
 
 	if bucketRegionSet || bucketRegion != "" {

--- a/s3/stow_test.go
+++ b/s3/stow_test.go
@@ -42,40 +42,10 @@ func TestStow(t *testing.T) {
 }
 
 func TestPreSignedURL(t *testing.T) {
-	fileData := make(map[string]string)
-	content, err := os.ReadFile(os.Getenv("AWSCREDENTIALSLOCATION"))
-	if err != nil {
-		fmt.Println("Error reading file:", err)
-		return
-	}
-	lines := strings.Split(string(content), "\n")
-
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			continue
-		}
-
-		parts := strings.Split(line, "=")
-		if len(parts) != 2 {
-			fmt.Println("Invalid line:", line)
-			continue
-		}
-
-		key := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-
-		fileData[key] = value
-	}
-
-	accessKeyId := fileData["aws_access_key_id"]
-	secretKey := fileData["aws_secret_access_key"]
-	region := "us-west-2"
-
 	is := is.New(t)
-	// accessKeyId := os.Getenv("S3ACCESSKEYID")
-	// secretKey := os.Getenv("S3SECRETKEY")
-	// region := os.Getenv("S3REGION")
+	accessKeyId := os.Getenv("S3ACCESSKEYID")
+	secretKey := os.Getenv("S3SECRETKEY")
+	region := os.Getenv("S3REGION")
 
 	if accessKeyId == "" || secretKey == "" || region == "" {
 		t.Skip("skipping test because missing one or more of S3ACCESSKEYID S3SECRETKEY S3REGION")
@@ -90,7 +60,7 @@ func TestPreSignedURL(t *testing.T) {
 	location, err := stow.Dial("s3", config)
 	is.NoErr(err)
 
-	container, err := location.Container(os.Getenv("AWSS3BUCKET"))
+	container, err := location.Container("flyte-demo")
 	if err != nil {
 		t.Skip(err)
 	}

--- a/test/test.go
+++ b/test/test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -18,6 +17,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/cheekybits/is"
 	"github.com/flyteorg/stow"


### PR DESCRIPTION
Part of a group:
1. [This PR] (land this first) https://github.com/flyteorg/stow/pull/11
2. https://github.com/flyteorg/flyte/pull/4897
3. https://github.com/flyteorg/flytekit/pull/2193

## Problem

S3 Stow implementation does not yet support setting [ServerSideEncryption (SSE)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html). We are particularly interested in the [AWS Key Management Service (KMS)](https://docs.aws.amazon.com/kms/latest/developerguide/overview.html) case.

## Solution
Add a new `extra_args` key to the stow config, which contains the keys/values like `ServerSideEncryption: x, SSEKMSKeyId: x`, that are passed through to the s3 stow container and used in S3 operations such as `Presign PutObjectRequest`.

If the above fails - when the authenticated S3 account has `s3:GetEncryptionConfiguration` permissions, get the sse keys/values using that permission, to continue the flow. This logic is adapted from https://github.com/aws/amazon-ssm-agent/blob/dff1ac44e0eb5a3c5138c754b6c423098ed7bd0c/agent/s3util/s3util.go#L164

Otherwise, the normal path (no SSE) is taken i.e. for backwards-compatability.

## Testing

Tested together with https://github.com/flyteorg/flyte/pull/4897 https://github.com/flyteorg/flytekit/pull/2193 on a Flyte deployment, against an S3 bucket with policy denying any request without `"s3:x-amz-server-side-encryption": "aws:kms"`.

```
(Pdb) rsp.url
'https://...s3.us-west-2.amazonaws.com/...&X-Amz-SignedHeaders=content-md5%3Bhost%3B
x-amz-server-side-encryption%3Bx-amz-server-side-encryption-aws-kms-key-id
&x-amz-server-side-encryption=aws%3Akms&x-amz-server-side-encryption-aws-kms-key-id=...
&X-Amz-Signature=...'
(Pdb) rsp.status_code
200
(Pdb) rsp.headers
{'x-amz-id-2': '...', 'x-amz-request-id': '...', 'Date': 'Thu, 15 Feb 2024 23:28:48 GMT', 
'x-amz-server-side-encryption': 'aws:kms', 'x-amz-server-side-encryption-aws-kms-key-id': ''...', 
'Server': 'AmazonS3', ...}
```