### PR TITLE
Add ssekmsid to config

### DIFF
--- a/s3/config.go
+++ b/s3/config.go
@@ -50,6 +50,10 @@ const (
 	// Its default value is "false", to enable set to "true".
 	// This feature is useful for s3-compatible blob stores -- ie minio.
 	ConfigV2Signing = "v2_signing"
+
+	// ConfigSSEKMSID is an optional config value for s3 buckets using server-side encryption.
+	// It specifies the id of the KMS key used to encrypt/decrypt objects in the bucket.
+	ConfigSSEKMSID = "sse_kms_id"
 )
 
 func init() {


### PR DESCRIPTION
## Problem

S3 Stow implementation does not yet support setting [ServerSideEncryption (SSE)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html). We are particularly interested in the [AWS Key Management Service (KMS)](https://docs.aws.amazon.com/kms/latest/developerguide/overview.html) case.

## Solution

Add a new `SSEKMSKeyId` key to the stow config, which will pass-through/override in the S3 bucket ops referenced in https://github.com/flyteorg/stow/pull/11

## Testing

...