### PR TITLE
Fix: Correct google stow item url format

### DIFF
--- a/google/config.go
+++ b/google/config.go
@@ -15,6 +15,7 @@ import (
 
 // Kind represents the name of the location/storage type.
 const Kind = "google"
+const Protocol = "gs"
 
 const (
 	// The service account json blob

--- a/google/container.go
+++ b/google/container.go
@@ -150,10 +150,7 @@ func merge(metadata ...map[string]string) map[string]string {
 }
 
 func (c *Container) convertToStowItem(attr *storage.ObjectAttrs) (stow.Item, error) {
-	u, err := prepUrl(attr.MediaLink)
-	if err != nil {
-		return nil, err
-	}
+	u := prepUrl(attr)
 
 	mdParsed, err := parseMetadata(attr.Metadata)
 	if err != nil {

--- a/google/item.go
+++ b/google/item.go
@@ -75,15 +75,21 @@ func (i *Item) StorageObject() *storage.ObjectAttrs {
 	return i.object
 }
 
-// prepUrl takes a MediaLink string and returns a url
-func prepUrl(str string) (*url.URL, error) {
-	u, err := url.Parse(str)
-	if err != nil {
-		return nil, err
+// prepUrl takes ObjectAttrs and returns a url constructed from the bucket and name.
+// We don't use attr.MediaLink because it is in the format
+// `google://storage.googleapis.com/download/storage/v1/b/some-bucket/...` instead of
+// `gs://some-bucket/...`.
+// Otherwise, when using stow to list a bucket `gs://...`, the resulting objects
+// `google://storage.googleapis.com/download/storage/v1/b/...` could not be found
+// using the same stow client.
+func prepUrl(attr *storage.ObjectAttrs) *url.URL {
+	u := url.URL{
+		Scheme: Protocol,
+		Host:   attr.Bucket,
+		Path:   attr.Name,
 	}
-	u.Scheme = "google"
 
 	// Discard the query string
 	u.RawQuery = ""
-	return u, nil
+	return &u
 }


### PR DESCRIPTION
For RFC https://github.com/flyteorg/flyte/pull/5598, flytepropeller was given the ability to list error files in the so-called raw output prefix bucket of an execution with the goal of identifying which worker pod in a failed distributed task experienced the first error.

For this purpose, the `StowStore` in flytestdlib was given a `List` function.

For google cloud storage buckets, the listing and subsequent access of the error files currently does not work: When listing a bucket `gs://some-bucket/...`, one receives items in the form `google://storage.googleapis.com/download/storage/v1/b/some-bucket/...` which then cannot be found by the stow store for the `gs://` prefix.

This PR fixes the URL format in the underlying stow library.