### PR TITLE
Introduce new config disable_force_path_style for S3

### DIFF
--- a/s3/config.go
+++ b/s3/config.go
@@ -158,7 +158,13 @@ func newS3Client(config stow.Config, region string) (client *s3.S3, endpoint str
 
 	endpoint, ok := config.Config(ConfigEndpoint)
 	if ok {
-		awsConfig.WithEndpoint(endpoint).WithS3ForcePathStyle(false)
+		awsConfig.WithEndpoint(endpoint)
+		disableForcePathStyle, ok := config.Config(ConfigDisableForcePathStyle)
+		if ok && disableForcePathStyle == "true" {
+			awsConfig.WithS3ForcePathStyle(false)
+		} else {
+			awsConfig.WithS3ForcePathStyle(true)
+		}
 	}
 
 	disableSSL, ok := config.Config(ConfigDisableSSL)

--- a/s3/config.go
+++ b/s3/config.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -159,12 +160,15 @@ func newS3Client(config stow.Config, region string) (client *s3.S3, endpoint str
 	endpoint, ok := config.Config(ConfigEndpoint)
 	if ok {
 		awsConfig.WithEndpoint(endpoint)
-		disableForcePathStyle, ok := config.Config(ConfigDisableForcePathStyle)
-		if ok && disableForcePathStyle == "true" {
-			awsConfig.WithS3ForcePathStyle(false)
-		} else {
-			awsConfig.WithS3ForcePathStyle(true)
-		}
+	}
+
+	disablePathStyle, _ := config.Config(ConfigDisableForcePathStyle)
+	if disablePathStyle == "true" {
+		fmt.Printf("Setting s3 force style true")
+		awsConfig.WithS3ForcePathStyle(false)
+	} else if endpoint != "" {
+		fmt.Printf("Setting s3 force style false")
+		awsConfig.WithS3ForcePathStyle(true)
 	}
 
 	disableSSL, ok := config.Config(ConfigDisableSSL)

--- a/s3/config.go
+++ b/s3/config.go
@@ -42,6 +42,9 @@ const (
 	// used for e.g. minio.io
 	ConfigEndpoint = "endpoint"
 
+	// ConfigDisableForcePathStyle is optional config value to disable default force path style
+	ConfigDisableForcePathStyle = "disable_force_path_style"
+
 	// ConfigDisableSSL is optional config value for disabling SSL support on custom endpoints
 	// Its default value is "false", to disable SSL set it to "true".
 	ConfigDisableSSL = "disable_ssl"
@@ -155,8 +158,13 @@ func newS3Client(config stow.Config, region string) (client *s3.S3, endpoint str
 
 	endpoint, ok := config.Config(ConfigEndpoint)
 	if ok {
-		awsConfig.WithEndpoint(endpoint).
-			WithS3ForcePathStyle(true)
+		awsConfig.WithEndpoint(endpoint)
+		disableForcePathStyle, ok := config.Config(ConfigDisableForcePathStyle)
+		if ok && disableForcePathStyle == "true" {
+			awsConfig.WithS3ForcePathStyle(false)
+		} else {
+			awsConfig.WithS3ForcePathStyle(true)
+		}
 	}
 
 	disableSSL, ok := config.Config(ConfigDisableSSL)

--- a/s3/config.go
+++ b/s3/config.go
@@ -1,7 +1,6 @@
 package s3
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -159,16 +158,7 @@ func newS3Client(config stow.Config, region string) (client *s3.S3, endpoint str
 
 	endpoint, ok := config.Config(ConfigEndpoint)
 	if ok {
-		awsConfig.WithEndpoint(endpoint)
-	}
-
-	disablePathStyle, _ := config.Config(ConfigDisableForcePathStyle)
-	if disablePathStyle == "true" {
-		fmt.Printf("Setting s3 force style true")
-		awsConfig.WithS3ForcePathStyle(false)
-	} else if endpoint != "" {
-		fmt.Printf("Setting s3 force style false")
-		awsConfig.WithS3ForcePathStyle(true)
+		awsConfig.WithEndpoint(endpoint).WithS3ForcePathStyle(false)
 	}
 
 	disableSSL, ok := config.Config(ConfigDisableSSL)


### PR DESCRIPTION
Currently within S3 config force path style is hardcoded to be true. Exposing the value via config.

**Context**
The current config assumes when an endpoint is supplied, it could be something like minio. We use S3-Compatible CAIOS which doesn't use path sytle and uses hostname style.

Related pr in flytekit
https://github.com/flyteorg/stow/pull/20